### PR TITLE
msgctxt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,22 @@ Creates a new parser.
 The `keywordspec` parameter is optional, with the default being:
 ```javascript
 {
-  _: [0],
-  gettext: [0],
-  ngettext: [0, 1]
+  gettext: ['msgid'],
+  _: ['msgid'],
+
+  ngettext: ['msgid', 'msgid_plural'],
+  n_: ['msgid', 'msgid_plural'],
+
+  pgettext: ['msgctxt', 'msgid'],
+  p_: ['msgctxt', 'msgid'],
+
+  npgettext: ['msgctxt', 'msgid', 'msgid_plural'],
+  np_: ['msgctxt', 'msgid', 'msgid_plural']
 }
 ```
-Each keyword (key) requires array of argument number(s) (value). When multiple argument numbers are specified, expressions using this keyword are treaded as single-plural.
+Each keyword (key) requires array of strings indicating the order of expected PO fields.
+For example `npgettext: ['msgctxt', 'msgid', 'msgid_plural']` indicates that the
+`npgettext` handlebars helper takes arguments of form `{{npgettext "context" "string" "plural" ...}}`
 
 #### .parse(template)
 Parses the `template` string for Handlebars expressions using the keywordspec.
@@ -29,6 +39,9 @@ It returns an object with this structure:
   msgid2: {
     line: [2],
     plural: 'msgid_plural'
+  },
+  context\u0004msgid2: {
+    line: [4]
   }
 }
 ```

--- a/index.js
+++ b/index.js
@@ -3,6 +3,11 @@
 var Handlebars = require('handlebars');
 
 function Parser (keywordSpec) {
+  // make new optional
+  if (!(this instanceof Parser)) {
+    return new Parser(keywordSpec);
+  }
+
   var gettextSpec = ['msgid'];
   var ngettextSpec = ['msgid', 'msgid_plural'];
   var pgettextSpec = ['msgctxt', 'msgid'];

--- a/test/fixtures/contexts.hbs
+++ b/test/fixtures/contexts.hbs
@@ -1,0 +1,4 @@
+{{pgettext "pgettext context" "pgettext_msgid"}}
+{{p_ "p_ context" "p_msgid"}}
+{{npgettext "noun" "file" "files"}}
+{{np_ "verb" "file" "files"}}

--- a/test/fixtures/mismatched-plurals.hbs
+++ b/test/fixtures/mismatched-plurals.hbs
@@ -1,0 +1,3 @@
+{{! can't have the same msgid use different plurals }}
+{{ngettext "goose" "goose" amount}}
+{{ngettext 'goose' 'geese' amount}}

--- a/test/fixtures/skip-params.hbs
+++ b/test/fixtures/skip-params.hbs
@@ -1,0 +1,1 @@
+{{_ "ignored" "msgid" "plural"}}

--- a/test/index.js
+++ b/test/index.js
@@ -9,6 +9,21 @@ describe('Parser', function () {
         it('should have default keyword spec when none is passed', function () {
             assert((new Parser()).keywordSpec.gettext.length > 0);
           });
+
+        it('should convert int params to strings', function () {
+          assert.deepEqual((new Parser({_: [0]})).keywordSpec, {_: ['msgid']});
+          assert.deepEqual((new Parser({n_: [0, 1]})).keywordSpec, {n_: ['msgid', 'msgid_plural']});
+
+          var spec = new Parser({n_: [2, 1]}).keywordSpec.n_;
+          assert.equal(spec.length, 3);
+          assert.equal(spec[1], 'msgid_plural');
+          assert.equal(spec[2], 'msgid');
+
+          spec = new Parser({n_: [1, 2]}).keywordSpec.n_;
+          assert.equal(spec.length, 3);
+          assert.equal(spec[1], 'msgid');
+          assert.equal(spec[2], 'msgid_plural');
+        });
       });
 
     describe('#parse()', function () {
@@ -67,5 +82,54 @@ describe('Parser', function () {
                 done();
               });
           });
+      });
+
+      it('should support skipping parameters', function (done) {
+        fs.readFile(__dirname + '/fixtures/skip-params.hbs', {encoding: 'utf8'}, function (err, data) {
+          if (err) {
+            throw err;
+          }
+
+          var result = new Parser({_: [1, 2]}).parse(data);
+
+          assert.equal(result.msgid.msgid, 'msgid');
+          assert.equal(result.msgid.msgid_plural, 'plural');
+
+          done();
+        });
+      });
+
+      it('should support extracting contexts', function (done) {
+        fs.readFile(__dirname + '/fixtures/contexts.hbs', {encoding: 'utf8'}, function (err, data) {
+          if (err) {
+            throw err;
+          }
+
+          var result = (new Parser()).parse(data);
+
+          var key = Parser.messageToKey('pgettext_msgid', 'pgettext context');
+          assert(key in result);
+          assert.equal(result[key].msgctxt, 'pgettext context');
+
+          key = Parser.messageToKey('p_msgid', 'p_ context');
+          assert(key in result);
+          assert.equal(result[key].msgctxt, 'p_ context');
+
+          key = Parser.messageToKey('file', 'noun');
+          assert(key in result);
+          assert.equal(result[key].msgctxt, 'noun');
+          assert.equal(result[key].msgid_plural, 'files');
+          assert.equal(result[key].plural, 'files');
+
+          key = Parser.messageToKey('file', 'verb');
+          assert(key in result);
+          assert.equal(result[key].msgctxt, 'verb');
+          assert.equal(result[key].msgid_plural, 'files');
+          assert.equal(result[key].plural, 'files');
+
+          assert.equal(4, Object.keys(result).length);
+
+          done();
+        });
       });
   });

--- a/test/index.js
+++ b/test/index.js
@@ -60,6 +60,18 @@ describe('Parser', function () {
               });
           });
 
+        it('should throw an error if there are mismatched plurals', function (done) {
+          fs.readFile(__dirname + '/fixtures/mismatched-plurals.hbs', {encoding: 'utf8'}, function (err, data) {
+            if (err) {
+              throw err;
+            }
+
+            assert.throws(function() { new Parser().parse(data); }, Error);
+
+            done();
+          });
+        });
+
         it('should recognize subexpressions', function (done) {
             fs.readFile(__dirname + '/fixtures/subexpression.hbs', {encoding: 'utf8'}, function (err, data) {
                 if (err) {

--- a/test/index.js
+++ b/test/index.js
@@ -144,4 +144,19 @@ describe('Parser', function () {
           done();
         });
       });
+
+      it('should support being called without `new`', function (done) {
+        /* jshint newcap: false */
+        fs.readFile(__dirname + '/fixtures/template.hbs', {encoding: 'utf8'}, function (err, data) {
+          if (err) {
+            throw err;
+          }
+
+          var result = Parser().parse(data);
+
+          assert('inside block' in result);
+
+          done();
+        });
+      });
   });


### PR DESCRIPTION
Closes #4 

This is a **major** rewrite to how things are extracted, but **it's fully backwards compatible**. It achieves this by using the same technique as Jed. Namely, it stores messages with contexts as messages with their context prepended. Hopefully the code is self-explanatory, but I can provide more details if needed. This should also make it easier to add [domain support](https://github.com/smhg/gettext-handlebars/issues/2), although that will probably require a breaking change to the return value of `.parse`.

