### PR TITLE
Process subexpressions in hashes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,6 +154,11 @@ Parser.prototype.parse = function (template) {
 
       // step into possible subexpressions
       statement.params.reduce(isMsg, msgs);
+      if (statement.hash) {
+        for (var i = 0; i < statement.hash.pairs.length; i++) {
+          isMsg(msgs, statement.hash.pairs[i].value);
+        }
+      }
 
       break;
     case 'BlockStatement':

--- a/test/fixtures/subexpression.hbs
+++ b/test/fixtures/subexpression.hbs
@@ -5,3 +5,5 @@
 {{sprintf (ngettext "%s %s other" "%s %s others" count) (sprintf (gettext "nested %s")) something}}
 {{sprintf "%s something" (inner "something else")}}
 {{gettext}}
+{{outer "regular" dummy_hash=(gettext "dummy_hash_text")}}
+{{outer dummy_hash=(gettext "dummy_hash_text_only")}}

--- a/test/index.js
+++ b/test/index.js
@@ -89,7 +89,9 @@ describe('Parser', function () {
         assert('regular' in result);
         assert('%s %s other' in result);
         assert('nested %s' in result);
-        assert.equal(7, Object.keys(result).length);
+        assert('dummy_hash_text' in result);
+        assert('dummy_hash_text_only' in result);
+        assert.equal(9, Object.keys(result).length);
 
         done();
       });


### PR DESCRIPTION
Subexpressions in hashes are currently not processed:

    {{input value=identification placeholder=(_ "Enter Login") class='form-control'}}

This PR fixes this.