### PR TITLE
Added support for subexpressions inside partial statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,6 +171,17 @@ Parser.prototype.parse = function (template) {
       }
 
       break;
+
+    case 'PartialStatement':
+      if (statement.hash && statement.hash.pairs) {
+        for (var j = 0; j < statement.hash.pairs.length; j++) {
+          if (statement.hash.pairs[j].value && statement.hash.pairs[j].value.type === 'SubExpression') {
+            isMsg(msgs, statement.hash.pairs[j].value);
+          }
+        }
+      }
+
+      break;
     }
 
     return msgs;

--- a/test/fixtures/subexpression.hbs
+++ b/test/fixtures/subexpression.hbs
@@ -7,4 +7,4 @@
 {{gettext}}
 {{outer "regular" dummy_hash=(gettext "dummy_hash_text")}}
 {{outer dummy_hash=(gettext "dummy_hash_text_only")}}
-{{>partial/template label=(gettext "subexpression_from_from_partial")}}
+{{>partial/template label=(gettext "subexpression_from_from_partial") dummy="something else"}}

--- a/test/fixtures/subexpression.hbs
+++ b/test/fixtures/subexpression.hbs
@@ -7,3 +7,4 @@
 {{gettext}}
 {{outer "regular" dummy_hash=(gettext "dummy_hash_text")}}
 {{outer dummy_hash=(gettext "dummy_hash_text_only")}}
+{{>partial/template label=(gettext "subexpression_from_from_partial")}}

--- a/test/index.js
+++ b/test/index.js
@@ -91,7 +91,8 @@ describe('Parser', function () {
         assert('nested %s' in result);
         assert('dummy_hash_text' in result);
         assert('dummy_hash_text_only' in result);
-        assert.equal(9, Object.keys(result).length);
+        assert('subexpression_from_from_partial' in result);
+        assert.equal(10, Object.keys(result).length);
 
         done();
       });


### PR DESCRIPTION
Hi,

Thanks for you work!

I've added support for gettext as subexpression inside a partial statement. In my opinion a lot of people who use handlebars might enjoy this. 

Added an unit test for this new feature, also tested it with a large real world application with 500+ handlebars templates.

I do not create pull requests very often. Just let me know if i need to change something.

See the chapter Partials on the webpage below for info on partials.
http://blog.teamtreehouse.com/handlebars-js-part-2-partials-and-helpers
